### PR TITLE
Allow diff step to error and continue cleanly on no change

### DIFF
--- a/.github/workflows/update_tz_data.yml
+++ b/.github/workflows/update_tz_data.yml
@@ -39,14 +39,14 @@ jobs:
           python update.py
 
       - name: Check if tzdata has been updated
+        id: diff-check
         run: |
-          ! git diff --exit-code eos-tzdata/VERSION
+          git diff --exit-code eos-tzdata/VERSION || echo "NO_CHANGE=true" >> "${GITHUB_OUTPUT}"
 
       - name: Commit and PR changes
         # the --exit-code above will return 1 (fail) if the file given has changed
-        # we negate that with `!`
-        # success() ensures the previous job succeeds
-        if: ${{ success() }}
+        # this checks that the conclusion of that job is a failure, meaning changes
+        if: steps.diff-check.outputs.NO_CHANGE == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           add-paths: |


### PR DESCRIPTION
Additional to my previous PR, which can result in an unhandled error.

This PR allows the shell step which checks for a `VERSION` diff to error, upon which we handle it and go on to create the updated files PR.

If the step succeeds, we skip creating the PR step and allow the action to exit cleanly.