### PR TITLE
fix parsing of short april

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -881,10 +881,18 @@ impl<'a> FormatSpec<'a> {
                             None => return Err(ParseError::UnexpectedEnd),
                         };
                     }
-                    Some(b'A') => {
-                        parser.expect_str(b"ug")?;
-                        builder.month(8);
-                    }
+                    Some(b'A') => match parser.advance() {
+                        Some(b'p') => {
+                            parser.expect(b'r')?;
+                            builder.month(4);
+                        }
+                        Some(b'u') => {
+                            parser.expect(b'g')?;
+                            builder.month(8);
+                        }
+                        Some(c) => return Err(ParseError::UnexpectedChar(c as char)),
+                        None => return Err(ParseError::UnexpectedEnd),
+                    },
                     Some(b'S') => {
                         parser.expect_str(b"ep")?;
                         builder.month(9);

--- a/tests/fmt.rs
+++ b/tests/fmt.rs
@@ -218,4 +218,8 @@ fn test_april() {
     let spec = eos::fmt::format_spec!("%B %d, %Y");
     let site_date = eos::DateTime::parse_from_spec("April 3, 2025", spec).unwrap().date();
     assert_eq!(site_date, date!(2025 - 04 - 03));
+
+    let spec = eos::fmt::format_spec!("%b %d, %Y");
+    let site_date = eos::DateTime::parse_from_spec("Apr 3, 2025", spec).unwrap().date();
+    assert_eq!(site_date, date!(2025 - 04 - 03));
 }


### PR DESCRIPTION
Dates like `Apr 3, 2025` with the format spec `%b %d, %Y` would fail to parse.